### PR TITLE
Fix: Convert 'shared' to string before calling add_share

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -84,7 +84,7 @@ class Main:
                     })
 
                 self.collector.approval(approval)
-                if shared != '공람없음':
+                if shared is not None and shared != '공람없음':
                     shared_as_str = str(shared)
                     self.collector.add_share(shared_as_str)
 

--- a/src/main.py
+++ b/src/main.py
@@ -85,7 +85,8 @@ class Main:
 
                 self.collector.approval(approval)
                 if shared != '공람없음':
-                    self.collector.add_share(shared)
+                    shared_as_str = str(shared)
+                    self.collector.add_share(shared_as_str)
 
                 print(
                     f"{title} -> {approval} / {shared}")


### PR DESCRIPTION
Pylance reported a type error where an argument of type 'str | int | None' was being passed to the 'add_share' function, which expected 'str' for the 'share_name' parameter.

This was caused when the 'shared' variable, derived from 'item["share"]' in 'sort_data.json' via the '_check_sort' method, contained an integer value.

The fix explicitly converts the 'shared' variable to a string using str(shared) before it is passed to self.collector.add_share(). This ensures that 'add_share' always receives a string argument, resolving the type error.