### PR TITLE
[HARNESS] Configure grouped Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       python-deps:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- group routine dependency updates
- limit grouped updates to minor and patch versions
- keep major updates separate for review

## Verification
- parsed .github/dependabot.yml successfully
- confirmed only Dependabot configuration changed